### PR TITLE
Make sure AccountSetupViewModel is only created once

### DIFF
--- a/src/viewmodels/RootViewModel.ts
+++ b/src/viewmodels/RootViewModel.ts
@@ -94,14 +94,16 @@ export class RootViewModel extends ViewModel {
 
     private _showAccountSetup() {
         this._activeSection = "account-setup";
-        this._accountSetupViewModel = this.track(new AccountSetupViewModel(
-            this.childOptions({
-                client: this._client,
-                config: this._config,
-                state: this._state,
-                footerVM: this._footerViewModel,
-            })
-        ));
+        if(!this._accountSetupViewModel) {
+            this._accountSetupViewModel = this.track(new AccountSetupViewModel(
+                this.childOptions({
+                    client: this._client,
+                    config: this._config,
+                    state: this._state,
+                    footerVM: this._footerViewModel,
+                })
+            ));
+        }
         this.emitChange("activeSection");
     }
 


### PR DESCRIPTION
Chatterbox currently creates two instances of `AccountSetupViewModel` when it is opened for the first time. Each one registers a separate account on the server, and Chatterbox ends up crashing as a result. This change makes Chatterbox reuse the `AccountSetupViewModel` if it already exists, similarly to what 8aa7ba43ccc5171ccb8b4f1ee5ee55774f3a67c6 added for the `ChatterboxViewModel`.

Fixes #105.